### PR TITLE
The file size extraction from the description of RSS feed (#580)

### DIFF
--- a/daemon/feed/FeedFile.h
+++ b/daemon/feed/FeedFile.h
@@ -23,6 +23,7 @@
 #define FEEDFILE_H
 
 #include <string>
+#include <string_view>
 #include "FeedInfo.h"
 
 class FeedFile
@@ -53,6 +54,13 @@ private:
 	void Parse_StartElement(const char *name, const char **atts);
 	void Parse_EndElement(const char *name);
 	void Parse_Content(std::string content);
+
+	/**
+	 * Extracts the file size in bytes from a description string.
+	 * Some RSS feeds embed the file size directly within the description text.
+	 * Example description string: "Total Size : 299.6 MB | MultiUp"
+	 */
+	int64 ExtractSizeFromDescription(std::string_view description);
 	void ResetTagContent();
 };
 

--- a/daemon/feed/FeedInfo.h
+++ b/daemon/feed/FeedInfo.h
@@ -2,6 +2,7 @@
  *  This file is part of nzbget. See <https://nzbget.com>.
  *
  *  Copyright (C) 2013-2016 Andrey Prygunkov <hugbug@users.sourceforge.net>
+ *  Copyright (C) 2025 Denis <denis@nzbget.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,14 +15,14 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 
 #ifndef FEEDINFO_H
 #define FEEDINFO_H
 
-#include "NString.h"
+#include <string>
 #include "Util.h"
 #include "DownloadInfo.h"
 
@@ -36,19 +37,28 @@ public:
 		fsFailed
 	};
 
-	FeedInfo(int id, const char* name, const char* url, bool backlog, int interval,
-		const char* filter, bool pauseNzb, const char* category, int priority,
-		const char* extensions);
+	FeedInfo(
+		int id,
+		const char* name,
+		const char* url,
+		bool backlog,
+		int interval,
+		const char* filter,
+		bool pauseNzb,
+		const char* category,
+		int priority,
+		const char* extensions
+	);
 	int GetId() { return m_id; }
-	const char* GetName() { return m_name; }
-	const char* GetUrl() { return m_url; }
+	const char* GetName() const { return m_name.c_str(); }
+	const char* GetUrl() const { return m_url.c_str(); }
 	int GetInterval() { return m_interval; }
-	const char* GetFilter() { return m_filter; }
+	const char* GetFilter() const { return m_filter.c_str(); }
 	uint32 GetFilterHash() { return m_filterHash; }
 	bool GetPauseNzb() { return m_pauseNzb; }
-	const char* GetCategory() { return m_category; }
+	const char* GetCategory() const { return m_category.c_str(); }
 	int GetPriority() { return m_priority; }
-	const char* GetExtensions() { return m_extensions; }
+	const char* GetExtensions() const { return m_extensions.c_str(); }
 	time_t GetLastUpdate() { return m_lastUpdate; }
 	void SetLastUpdate(time_t lastUpdate) { m_lastUpdate = lastUpdate; }
 	time_t GetNextUpdate() { return m_nextUpdate; }
@@ -59,8 +69,8 @@ public:
 	void SetPreview(bool preview) { m_preview = preview; }
 	EStatus GetStatus() { return m_status; }
 	void SetStatus(EStatus Status) { m_status = Status; }
-	const char* GetOutputFilename() { return m_outputFilename; }
-	void SetOutputFilename(const char* outputFilename) { m_outputFilename = outputFilename; }
+	const char* GetOutputFilename() const { return m_outputFilename.c_str(); }
+	void SetOutputFilename(const char* outputFilename) { m_outputFilename = outputFilename ? outputFilename : ""; }
 	bool GetFetch() { return m_fetch; }
 	void SetFetch(bool fetch) { m_fetch = fetch; }
 	bool GetForce() { return m_force; }
@@ -70,22 +80,22 @@ public:
 
 private:
 	int m_id;
-	CString m_name;
-	CString m_url;
-	bool m_backlog;
-	int m_interval;
-	CString m_filter;
-	uint32 m_filterHash;
-	bool m_pauseNzb;
-	CString m_category;
-	CString m_extensions;
-	int m_priority;
+	std::string m_name;
+	std::string m_url;
+	std::string m_category;
+	std::string m_extensions;
+	std::string m_filter;
+	std::string m_outputFilename;
 	time_t m_lastUpdate = 0;
 	time_t m_nextUpdate = 0;
-	int m_lastInterval = 0;
-	bool m_preview = false;
+	uint32 m_filterHash;
 	EStatus m_status = fsUndefined;
-	CString m_outputFilename;
+	int m_interval;
+	int m_priority;
+	int m_lastInterval = 0;
+	bool m_backlog;
+	bool m_pauseNzb;
+	bool m_preview = false;
 	bool m_fetch = false;
 	bool m_force = false;
 };
@@ -120,13 +130,15 @@ public:
 	class Attr
 	{
 	public:
-		Attr(const char* name, const char* value) :
-			m_name(name ? name : ""), m_value(value ? value : "") {}
-		const char* GetName() { return m_name; }
-		const char* GetValue() { return m_value; }
+		Attr(const char* name, const char* value)
+			: m_name(name ? name : "")
+			, m_value(value ? value : "") 
+		{ }
+		const char* GetName() const { return m_name.c_str(); }
+		const char* GetValue() const { return m_value.c_str(); }
 	private:
-		CString m_name;
-		CString m_value;
+		std::string m_name;
+		std::string m_value;
 	};
 
 	typedef std::deque<Attr> AttributesBase;
@@ -140,16 +152,16 @@ public:
 	FeedItemInfo() {}
 	FeedItemInfo(FeedItemInfo&&) = delete; // catch performance issues
 	void SetFeedFilterHelper(FeedFilterHelper* feedFilterHelper) { m_feedFilterHelper = feedFilterHelper; }
-	const char* GetTitle() { return m_title; }
-	void SetTitle(const char* title) { m_title = title; }
-	const char* GetFilename() { return m_filename; }
-	void SetFilename(const char* filename) { m_filename = filename; }
-	const char* GetUrl() { return m_url; }
-	void SetUrl(const char* url) { m_url = url; }
+	const char* GetTitle() const { return m_title.c_str(); }
+	void SetTitle(const char* title) { m_title = title ? title : ""; }
+	const char* GetFilename() const { return m_filename.c_str(); }
+	void SetFilename(const char* filename) { m_filename = filename ? filename : ""; }
+	const char* GetUrl() const { return m_url.c_str(); }
+	void SetUrl(const char* url) { m_url = url ? url : ""; }
 	int64 GetSize() { return m_size; }
 	void SetSize(int64 size) { m_size = size; }
-	const char* GetCategory() { return m_category; }
-	void SetCategory(const char* category) { m_category = category; }
+	const char* GetCategory() const { return m_category.c_str(); }
+	void SetCategory(const char* category) { m_category = category ? category : ""; }
 	int GetImdbId() { return m_imdbId; }
 	void SetImdbId(int imdbId) { m_imdbId = imdbId; }
 	int GetRageId() { return m_rageId; }
@@ -158,15 +170,15 @@ public:
 	void SetTvdbId(int tvdbId) { m_tvdbId = tvdbId; }
 	int GetTvmazeId() { return m_tvmazeId; }
 	void SetTvmazeId(int tvmazeId) { m_tvmazeId = tvmazeId; }
-	const char* GetDescription() { return m_description; }
+	const char* GetDescription() const { return m_description.c_str(); }
 	void SetDescription(const char* description) { m_description = description ? description: ""; }
-	const char* GetSeason() { return m_season; }
+	const char* GetSeason() const { return m_season.c_str(); }
 	void SetSeason(const char* season);
-	const char* GetEpisode() { return m_episode; }
+	const char* GetEpisode() const { return m_episode.c_str(); }
 	void SetEpisode(const char* episode);
 	int GetSeasonNum();
 	int GetEpisodeNum();
-	const char* GetAddCategory() { return m_addCategory; }
+	const char* GetAddCategory() const { return m_addCategory.c_str(); }
 	void SetAddCategory(const char* addCategory) { m_addCategory = addCategory ? addCategory : ""; }
 	bool GetPauseNzb() { return m_pauseNzb; }
 	void SetPauseNzb(bool pauseNzb) { m_pauseNzb = pauseNzb; }
@@ -180,7 +192,7 @@ public:
 	void SetMatchStatus(EMatchStatus matchStatus) { m_matchStatus = matchStatus; }
 	int GetMatchRule() { return m_matchRule; }
 	void SetMatchRule(int matchRule) { m_matchRule = matchRule; }
-	const char* GetDupeKey() { return m_dupeKey; }
+	const char* GetDupeKey() const { return m_dupeKey.c_str(); }
 	void SetDupeKey(const char* dupeKey) { m_dupeKey = dupeKey ? dupeKey : ""; }
 	void AppendDupeKey(const char* extraDupeKey);
 	void BuildDupeKey(const char* rageId, const char* tvdbId, const char* tvmazeId, const char* series);
@@ -192,32 +204,32 @@ public:
 	Attributes* GetAttributes() { return &m_attributes; }
 
 private:
-	CString m_title;
-	CString m_filename;
-	CString m_url;
+	std::string m_title;
+	std::string m_filename;
+	std::string m_url;
+	std::string m_category;
+	std::string m_description;
+	std::string m_season;
+	std::string m_episode;
+	std::string m_addCategory;
+	std::string m_dupeKey;
+	std::string m_dupeStatus;
 	time_t m_time = 0;
 	int64 m_size = 0;
-	CString m_category = "";
 	int m_imdbId = 0;
 	int m_rageId = 0;
 	int m_tvdbId = 0;
 	int m_tvmazeId = 0;
-	CString m_description = "";
-	CString m_season;
-	CString m_episode;
 	int m_seasonNum = 0;
 	int m_episodeNum = 0;
 	bool m_seasonEpisodeParsed = false;
-	CString m_addCategory = "";
 	bool m_pauseNzb = false;
 	int m_priority = 0;
 	EStatus m_status = isUnknown;
 	EMatchStatus m_matchStatus = msIgnored;
 	int m_matchRule = 0;
-	CString m_dupeKey;
 	int m_dupeScore = 0;
 	EDupeMode m_dupeMode = dmScore;
-	CString m_dupeStatus;
 	FeedFilterHelper* m_feedFilterHelper = nullptr;
 	Attributes m_attributes;
 
@@ -237,16 +249,18 @@ public:
 		hsFetched
 	};
 
-	FeedHistoryInfo(const char* url, EStatus status, time_t lastSeen) :
-		m_url(url), m_status(status), m_lastSeen(lastSeen) {}
-	const char* GetUrl() { return m_url; }
+	FeedHistoryInfo(const char* url, EStatus status, time_t lastSeen) 
+		: m_url{ url ? url : "" }
+		, m_status{ status }
+		, m_lastSeen{ lastSeen } {}
+	const char* GetUrl() const { return m_url.c_str(); }
 	EStatus GetStatus() { return m_status; }
 	void SetStatus(EStatus Status) { m_status = Status; }
 	time_t GetLastSeen() { return m_lastSeen; }
 	void SetLastSeen(time_t lastSeen) { m_lastSeen = lastSeen; }
 
 private:
-	CString m_url;
+	std::string m_url;
 	EStatus m_status;
 	time_t m_lastSeen;
 };

--- a/tests/feed/FeedFileTest.cpp
+++ b/tests/feed/FeedFileTest.cpp
@@ -29,6 +29,8 @@ const std::string CURR_DIR = FileSystem::GetCurrentDirectory().Str();
 BOOST_AUTO_TEST_CASE(FeedFileTest)
 {
 	const std::string testFile = CURR_DIR + "/feed/feed.xml";
+	const std::string filename = "Crows.And.Sparrows";
+	const std::string description = "   Title:     Test.Title         Added to index:     09/05/2025 14:05:12        Total Size         : 200.0 B         Weblink:     N/A";
 	FeedFile file(testFile.c_str(), "feedName");
 
 	BOOST_CHECK_EQUAL(file.Parse(), true);
@@ -37,6 +39,7 @@ BOOST_AUTO_TEST_CASE(FeedFileTest)
 	FeedItemInfo& feedInfo = items.get()->back();
 
 	BOOST_CHECK_EQUAL(feedInfo.GetCategory(), std::string("Movies>HD"));
+	BOOST_CHECK_EQUAL(feedInfo.GetTime(), 1701668883);
 	BOOST_CHECK_EQUAL(feedInfo.GetEpisode(), std::string("1"));
 	BOOST_CHECK_EQUAL(feedInfo.GetEpisodeNum(), 1);
 	BOOST_CHECK_EQUAL(feedInfo.GetSeason(), std::string("S03"));
@@ -46,10 +49,42 @@ BOOST_AUTO_TEST_CASE(FeedFileTest)
 	BOOST_CHECK_EQUAL(feedInfo.GetRageId(), 33877);
 	BOOST_CHECK_EQUAL(feedInfo.GetImdbId(), 42054);
 	BOOST_CHECK_EQUAL(feedInfo.GetUrl(), std::string("https://indexer.com/getnzb/nzb.nzb"));
-	BOOST_CHECK_EQUAL(feedInfo.GetDescription(), std::string("   Title:     Test.Title         Added to index:     09/05/2025 14:05:12         Weblink:     N/A"));
-	BOOST_CHECK_EQUAL(feedInfo.GetFilename(), std::string("Crows.And.Sparrows"));
+	BOOST_CHECK_EQUAL(feedInfo.GetDescription(), description);
+	BOOST_CHECK_EQUAL(feedInfo.GetFilename(), filename);
+	BOOST_CHECK_EQUAL(feedInfo.GetTitle(), filename);
 	BOOST_CHECK_EQUAL(feedInfo.GetSize(), 7445312955);
-	BOOST_CHECK_EQUAL(feedInfo.GetTitle(), std::string("Crows.And.Sparrows"));
+
+	xmlCleanupParser();
+}
+
+BOOST_AUTO_TEST_CASE(FeedFile2Test)
+{
+	const std::string testFile = CURR_DIR + "/feed/feed2.xml";
+	const std::string filename = "[Judas] Kimi to Boku no Saigo no Senjou, Aruiwa Sekai ga Hajimaru Seisen (Our Last Crusade or the Rise of a New World) - S02E08 [1080p][HEVC x265 10bit][Multi-Subs] (Weekly)";
+	const std::string description = "        Total Size         : 299.6 MB              |                                                    MultiUp    ";
+	const int64 size = static_cast<int64>(std::round(299.6 * 1024 * 1024));
+	FeedFile file(testFile.c_str(), "feedName");
+
+	BOOST_CHECK_EQUAL(file.Parse(), true);
+
+	std::unique_ptr<FeedItemList> items = file.DetachFeedItems();
+	FeedItemInfo& feedInfo = items.get()->back();
+
+	BOOST_CHECK_EQUAL(feedInfo.GetCategory(), std::string(""));
+	BOOST_CHECK_EQUAL(feedInfo.GetTime(), 1748526661);
+	BOOST_CHECK_EQUAL(feedInfo.GetEpisode(), std::string(""));
+	BOOST_CHECK_EQUAL(feedInfo.GetEpisodeNum(), 0);
+	BOOST_CHECK_EQUAL(feedInfo.GetSeason(), std::string(""));
+	BOOST_CHECK_EQUAL(feedInfo.GetSeasonNum(), 0);
+	BOOST_CHECK_EQUAL(feedInfo.GetTvmazeId(), 0);
+	BOOST_CHECK_EQUAL(feedInfo.GetTvdbId(), 0);
+	BOOST_CHECK_EQUAL(feedInfo.GetRageId(), 0);
+	BOOST_CHECK_EQUAL(feedInfo.GetImdbId(), 0);
+	BOOST_CHECK_EQUAL(feedInfo.GetUrl(), std::string("http://storage.animetosho.org/nzbs/000a9b44/%5BJudas%5D%20Kimisen%20-%20S02E08.nzb"));
+	BOOST_CHECK_EQUAL(feedInfo.GetDescription(), description);
+	BOOST_CHECK_EQUAL(feedInfo.GetFilename(), filename);
+	BOOST_CHECK_EQUAL(feedInfo.GetTitle(), filename);
+	BOOST_CHECK_EQUAL(feedInfo.GetSize(), size);
 
 	xmlCleanupParser();
 }

--- a/tests/testdata/feed/feed.xml
+++ b/tests/testdata/feed/feed.xml
@@ -21,7 +21,7 @@
    <comments>https://indexer.com/details/9bdef3a6cb1a370598f9af73ba50d40df354b327#comments</comments>
    <pubDate>Mon, 04 Dec 2023 05:48:03 +0000</pubDate>
    <category>Movies &gt; HD</category>
-   <description><![CDATA[<b>Title:</b> Test.Title<br /><b>Added to index:</b> 09/05/2025 14:05:12<br /><b>Weblink:</b> N/A]]></description>
+   <description><![CDATA[<b>Title:</b> Test.Title<br /><b>Added to index:</b> 09/05/2025 14:05:12<strong>Total Size</strong>: 200.0 B<br /><b>Weblink:</b> N/A]]></description>
    <enclosure url="https://indexer.com/getnzb/nzb.nzb" length="7445312955" type="application/x-nzb"/>
    <nZEDb:attr name="episode" value="1"/>
    <nZEDb:attr name="tvmazeid" value="33877"/>

--- a/tests/testdata/feed/feed2.xml
+++ b/tests/testdata/feed/feed2.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"
+	xmlns:atom="http://www.w3.org/2005/Atom">
+	<channel>
+		<atom:link href="https://feed.animetosho.org/rss2" rel="self" type="application/rss+xml"/>
+		<title>Anime Tosho</title>
+		<link>https://animetosho.org/</link>
+		<description>Latest releases feed</description>
+		<language>en-gb</language>
+		<ttl>30</ttl>
+		<lastBuildDate>Thu, 29 May 2025 13:51:01 +0000</lastBuildDate>
+		<item>
+			<title>[Judas] Kimi to Boku no Saigo no Senjou, Aruiwa Sekai ga Hajimaru Seisen (Our Last Crusade or the Rise of a New World) - S02E08 [1080p][HEVC x265 10bit][Multi-Subs] (Weekly)</title>
+			<description>
+				<![CDATA[<strong>Total Size</strong>: 299.6 MB<br/><strong> | <a href="https://multiup.io/download/20S02E08.mkv">MultiUp</a>]]>
+			</description>
+			<link>https://animetosho.org/view/judas-kimi-boku-no-saigo-senjou-aruiwa-sekai.n1976735</link>
+			<comments>https://animetosho.org/view/judas-kimi-boku-no-saigo-senjou-aruiwa-sekai.n1976735</comments>
+			<enclosure url="http://storage.animetosho.org/torrent/7b1e37207a060d0cf896d94cb4d35d26c1a75ba2/%5BJudas%5D%20Kimisen%20-%20S02E08.torrent" type="application/x-bittorrent" length="0"/>
+			<enclosure url="http://storage.animetosho.org/nzbs/000a9b44/%5BJudas%5D%20Kimisen%20-%20S02E08.nzb" type="application/x-nzb" length="0"/>
+			<source url="https://nyaa.si/view/1976735">Nyaa</source>
+			<pubDate>Thu, 29 May 2025 13:51:01 +0000</pubDate>
+			<guid isPermaLink="true">https://animetosho.org/view/a695108</guid>
+		</item>
+    </channel>
+</rss>


### PR DESCRIPTION
- added functionality to extract file size directly from the description of RSS feed. 
- Some RSS feeds embed the file size directly within the description text.
- refactoring: CString to std::string
- added more unit tests

## Description

Brief explanation of the goal, link issues covered (partially or fully resolved) by this pull request

## Lib changes

If vendored libraries are getting changed, please list new version, old version, and what kind of dependencies or restrictions it may introduce

## Testing

Mention smoke testing done or extra QA instructions